### PR TITLE
feat(accordion): add Multiple, Open, and Disabled props for shadcn-style parity

### DIFF
--- a/cmd/render-showcases/main.go
+++ b/cmd/render-showcases/main.go
@@ -29,7 +29,11 @@ func writeHTML(filename string, c templ.Component) error {
 func main() {
 	showcases := map[string]templ.Component{
 		// Accordion
-		"out/showcase/accordion_default.html": showcase.AccordionDefault(),
+		"out/showcase/accordion_default.html":  showcase.AccordionDefault(),
+		"out/showcase/accordion_multiple.html": showcase.AccordionMultiple(),
+		"out/showcase/accordion_disabled.html": showcase.AccordionDisabled(),
+		"out/showcase/accordion_borders.html":  showcase.AccordionBorders(),
+		"out/showcase/accordion_card.html":     showcase.AccordionCard(),
 
 		// Alert
 		"out/showcase/alert_default.html":     showcase.AlertDefault(),

--- a/components/accordion/accordion.templ
+++ b/components/accordion/accordion.templ
@@ -1,20 +1,34 @@
 package accordion
 
 import (
+	"context"
+
 	"github.com/templui/templui/components/icon"
 	"github.com/templui/templui/utils"
 )
+
+type contextKey struct{}
+
+type ctxData struct {
+	GroupName string
+	Multiple  bool
+	Disabled  bool
+}
 
 type Props struct {
 	ID         string
 	Class      string
 	Attributes templ.Attributes
+	Multiple   bool
+	Disabled   bool
 }
 
 type ItemProps struct {
 	ID         string
 	Class      string
 	Attributes templ.Attributes
+	Open       bool
+	Disabled   bool
 }
 
 type TriggerProps struct {
@@ -34,12 +48,22 @@ templ Accordion(props ...Props) {
 	if len(props) > 0 {
 		{{ p = props[0] }}
 	}
+	{{ groupName := p.ID }}
+	if groupName == "" {
+		{{ groupName = utils.RandomID() }}
+	}
+	{{ ctx = context.WithValue(ctx, contextKey{}, ctxData{
+		GroupName: groupName,
+		Multiple:  p.Multiple,
+		Disabled:  p.Disabled,
+	}) }}
 	<div
 		if p.ID != "" {
 			id={ p.ID }
 		}
 		class={
 			utils.TwMerge(
+				"flex w-full flex-col",
 				p.Class,
 			),
 		}
@@ -54,15 +78,25 @@ templ Item(props ...ItemProps) {
 	if len(props) > 0 {
 		{{ p = props[0] }}
 	}
+	{{ data := fromContext(ctx) }}
+	{{ disabled := p.Disabled || data.Disabled }}
 	<details
 		if p.ID != "" {
 			id={ p.ID }
 		}
-		name="accordion"
+		if !data.Multiple {
+			name={ data.GroupName }
+		}
+		open?={ p.Open }
+		inert?={ disabled }
+		if disabled {
+			aria-disabled="true"
+		}
 		class={
 			utils.TwMerge(
 				"group border-b last:border-b-0",
 				"[&[open]>summary>svg]:rotate-180",
+				utils.If(disabled, "pointer-events-none opacity-50"),
 				p.Class,
 			),
 		}
@@ -87,7 +121,7 @@ templ Trigger(props ...TriggerProps) {
 				"text-left text-sm font-medium",
 				"transition-all hover:underline cursor-pointer",
 				"outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:border-ring rounded-md",
-				"disabled:pointer-events-none disabled:opacity-50",
+				"aria-disabled:pointer-events-none aria-disabled:opacity-50",
 				"list-none [&::-webkit-details-marker]:hidden",
 				p.Class,
 			),
@@ -118,4 +152,11 @@ templ Content(props ...ContentProps) {
 	>
 		{ children... }
 	</div>
+}
+
+func fromContext(ctx context.Context) ctxData {
+	if data, ok := ctx.Value(contextKey{}).(ctxData); ok {
+		return data
+	}
+	return ctxData{}
 }

--- a/components/accordion/accordion_templ.go
+++ b/components/accordion/accordion_templ.go
@@ -9,20 +9,34 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
+	"context"
+
 	"github.com/templui/templui/components/icon"
 	"github.com/templui/templui/utils"
 )
+
+type contextKey struct{}
+
+type ctxData struct {
+	GroupName string
+	Multiple  bool
+	Disabled  bool
+}
 
 type Props struct {
 	ID         string
 	Class      string
 	Attributes templ.Attributes
+	Multiple   bool
+	Disabled   bool
 }
 
 type ItemProps struct {
 	ID         string
 	Class      string
 	Attributes templ.Attributes
+	Open       bool
+	Disabled   bool
 }
 
 type TriggerProps struct {
@@ -62,7 +76,17 @@ func Accordion(props ...Props) templ.Component {
 		if len(props) > 0 {
 			p = props[0]
 		}
+		groupName := p.ID
+		if groupName == "" {
+			groupName = utils.RandomID()
+		}
+		ctx = context.WithValue(ctx, contextKey{}, ctxData{
+			GroupName: groupName,
+			Multiple:  p.Multiple,
+			Disabled:  p.Disabled,
+		})
 		var templ_7745c5c3_Var2 = []any{utils.TwMerge(
+			"flex w-full flex-col",
 			p.Class,
 		),
 		}
@@ -82,7 +106,7 @@ func Accordion(props ...Props) templ.Component {
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(p.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/accordion/accordion.templ`, Line: 39, Col: 12}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/accordion/accordion.templ`, Line: 62, Col: 12}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -155,9 +179,12 @@ func Item(props ...ItemProps) templ.Component {
 		if len(props) > 0 {
 			p = props[0]
 		}
+		data := fromContext(ctx)
+		disabled := p.Disabled || data.Disabled
 		var templ_7745c5c3_Var6 = []any{utils.TwMerge(
 			"group border-b last:border-b-0",
 			"[&[open]>summary>svg]:rotate-180",
+			utils.If(disabled, "pointer-events-none opacity-50"),
 			p.Class,
 		),
 		}
@@ -177,7 +204,7 @@ func Item(props ...ItemProps) templ.Component {
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(p.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/accordion/accordion.templ`, Line: 59, Col: 12}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/accordion/accordion.templ`, Line: 85, Col: 12}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -188,20 +215,57 @@ func Item(props ...ItemProps) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, " name=\"accordion\" class=\"")
+		if !data.Multiple {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, " name=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var8 string
+			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(data.GroupName)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/accordion/accordion.templ`, Line: 88, Col: 24}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if p.Open {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, " open")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if disabled {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, " inert")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if disabled {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, " aria-disabled=\"true\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, " class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var8 string
-		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var6).String())
+		var templ_7745c5c3_Var9 string
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var6).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/accordion/accordion.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -209,7 +273,7 @@ func Item(props ...ItemProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, ">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, ">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -217,7 +281,7 @@ func Item(props ...ItemProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</details>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</details>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -241,66 +305,66 @@ func Trigger(props ...TriggerProps) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var9 == nil {
-			templ_7745c5c3_Var9 = templ.NopComponent
+		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var10 == nil {
+			templ_7745c5c3_Var10 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		var p TriggerProps
 		if len(props) > 0 {
 			p = props[0]
 		}
-		var templ_7745c5c3_Var10 = []any{utils.TwMerge(
+		var templ_7745c5c3_Var11 = []any{utils.TwMerge(
 			"flex flex-1 items-start justify-between gap-4 py-4",
 			"text-left text-sm font-medium",
 			"transition-all hover:underline cursor-pointer",
 			"outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:border-ring rounded-md",
-			"disabled:pointer-events-none disabled:opacity-50",
+			"aria-disabled:pointer-events-none aria-disabled:opacity-50",
 			"list-none [&::-webkit-details-marker]:hidden",
 			p.Class,
 		),
 		}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var10...)
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var11...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<summary")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<summary")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if p.ID != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, " id=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, " id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var11 string
-			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(p.ID)
+			var templ_7745c5c3_Var12 string
+			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(p.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/accordion/accordion.templ`, Line: 82, Col: 12}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/accordion/accordion.templ`, Line: 116, Col: 12}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, " class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, " class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var12 string
-		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var10).String())
+		var templ_7745c5c3_Var13 string
+		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var11).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/accordion/accordion.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -308,11 +372,11 @@ func Trigger(props ...TriggerProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, ">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, ">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templ_7745c5c3_Var9.Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = templ_7745c5c3_Var10.Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -320,7 +384,7 @@ func Trigger(props ...TriggerProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</summary>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</summary>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -344,61 +408,61 @@ func Content(props ...ContentProps) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var13 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var13 == nil {
-			templ_7745c5c3_Var13 = templ.NopComponent
+		templ_7745c5c3_Var14 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var14 == nil {
+			templ_7745c5c3_Var14 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		var p ContentProps
 		if len(props) > 0 {
 			p = props[0]
 		}
-		var templ_7745c5c3_Var14 = []any{utils.TwMerge(
+		var templ_7745c5c3_Var15 = []any{utils.TwMerge(
 			"pt-0 pb-4 text-sm overflow-hidden",
 			p.Class,
 		),
 		}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var14...)
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var15...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<div")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if p.ID != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, " id=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, " id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var15 string
-			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(p.ID)
+			var templ_7745c5c3_Var16 string
+			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(p.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/accordion/accordion.templ`, Line: 109, Col: 12}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/accordion/accordion.templ`, Line: 143, Col: 12}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, " class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, " class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var16 string
-		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var14).String())
+		var templ_7745c5c3_Var17 string
+		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var15).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/accordion/accordion.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -406,20 +470,27 @@ func Content(props ...ContentProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, ">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, ">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templ_7745c5c3_Var13.Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = templ_7745c5c3_Var14.Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		return nil
 	})
+}
+
+func fromContext(ctx context.Context) ctxData {
+	if data, ok := ctx.Value(contextKey{}).(ctxData); ok {
+		return data
+	}
+	return ctxData{}
 }
 
 var _ = templruntime.GeneratedTemplate

--- a/internal/ui/pages/accordion.templ
+++ b/internal/ui/pages/accordion.templ
@@ -1,4 +1,3 @@
-
 package pages
 
 import (
@@ -15,6 +14,28 @@ templ Accordion() {
 			{
 				ID:   "installation",
 				Text: "Installation",
+			},
+			{
+				ID:   "examples",
+				Text: "Examples",
+				Children: []modules.TableOfContentsItem{
+					{
+						ID:   "multiple",
+						Text: "Multiple",
+					},
+					{
+						ID:   "disabled",
+						Text: "Disabled",
+					},
+					{
+						ID:   "borders",
+						Text: "Borders",
+					},
+					{
+						ID:   "card",
+						Text: "Card",
+					},
+				},
 			},
 			{
 				ID:   "api",
@@ -73,6 +94,35 @@ templ Accordion() {
 				})
 			}
 			@modules.ContainerWrapper(modules.ContainerWrapperProps{
+				Title: "Examples",
+				ID:    "examples",
+			}) {
+				@modules.ExampleWrapper(modules.ExampleWrapperProps{
+					SectionName:     "Multiple",
+					ShowcaseFile:    showcase.AccordionMultiple(),
+					PreviewCodeFile: "accordion_multiple.templ",
+					ID:              "multiple",
+				})
+				@modules.ExampleWrapper(modules.ExampleWrapperProps{
+					SectionName:     "Disabled",
+					ShowcaseFile:    showcase.AccordionDisabled(),
+					PreviewCodeFile: "accordion_disabled.templ",
+					ID:              "disabled",
+				})
+				@modules.ExampleWrapper(modules.ExampleWrapperProps{
+					SectionName:     "Borders",
+					ShowcaseFile:    showcase.AccordionBorders(),
+					PreviewCodeFile: "accordion_borders.templ",
+					ID:              "borders",
+				})
+				@modules.ExampleWrapper(modules.ExampleWrapperProps{
+					SectionName:     "Card",
+					ShowcaseFile:    showcase.AccordionCard(),
+					PreviewCodeFile: "accordion_card.templ",
+					ID:              "card",
+				})
+			}
+			@modules.ContainerWrapper(modules.ContainerWrapperProps{
 				Title: "API Reference",
 				ID:    "api",
 			}) {
@@ -86,7 +136,7 @@ templ Accordion() {
 								Name:        "ID",
 								Type:        "string",
 								Default:     "",
-								Description: "Unique identifier for the accordion element.",
+								Description: "Unique identifier for the accordion. Also used as the exclusive group name when Multiple is false.",
 								Required:    false,
 							},
 							{
@@ -101,6 +151,20 @@ templ Accordion() {
 								Type:        "templ.Attributes",
 								Default:     "",
 								Description: "Additional HTML attributes to apply to the accordion element.",
+								Required:    false,
+							},
+							{
+								Name:        "Multiple",
+								Type:        "bool",
+								Default:     "false",
+								Description: "When true, multiple items can stay open at once. When false, items share an exclusive name group.",
+								Required:    false,
+							},
+							{
+								Name:        "Disabled",
+								Type:        "bool",
+								Default:     "false",
+								Description: "Disables all accordion items.",
 								Required:    false,
 							},
 						},
@@ -130,6 +194,20 @@ templ Accordion() {
 								Type:        "templ.Attributes",
 								Default:     "",
 								Description: "Additional HTML attributes to apply to the item element.",
+								Required:    false,
+							},
+							{
+								Name:        "Open",
+								Type:        "bool",
+								Default:     "false",
+								Description: "Renders the item open initially via the native open attribute.",
+								Required:    false,
+							},
+							{
+								Name:        "Disabled",
+								Type:        "bool",
+								Default:     "false",
+								Description: "Disables this item (combined with Accordion.Disabled from context).",
 								Required:    false,
 							},
 						},

--- a/internal/ui/showcase/accordion_borders.templ
+++ b/internal/ui/showcase/accordion_borders.templ
@@ -1,0 +1,43 @@
+package showcase
+
+import "github.com/templui/templui/components/accordion"
+
+templ AccordionBorders() {
+	<div class="w-full max-w-lg">
+		@accordion.Accordion(accordion.Props{
+			Class: "rounded-lg border",
+		}) {
+			@accordion.Item(accordion.ItemProps{
+				Open:  true,
+				Class: "border-b px-4 last:border-b-0",
+			}) {
+				@accordion.Trigger() {
+					How does billing work?
+				}
+				@accordion.Content() {
+					We offer monthly and annual subscription plans. Billing is charged at the beginning of each cycle, and you can cancel anytime.
+				}
+			}
+			@accordion.Item(accordion.ItemProps{
+				Class: "border-b px-4 last:border-b-0",
+			}) {
+				@accordion.Trigger() {
+					Is my data secure?
+				}
+				@accordion.Content() {
+					Yes. We use end-to-end encryption and regular third-party security audits. All data is encrypted at rest and in transit.
+				}
+			}
+			@accordion.Item(accordion.ItemProps{
+				Class: "border-b px-4 last:border-b-0",
+			}) {
+				@accordion.Trigger() {
+					What integrations do you support?
+				}
+				@accordion.Content() {
+					We integrate with popular tools including Slack, Zapier, and Salesforce. You can also build custom integrations using our REST API.
+				}
+			}
+		}
+	</div>
+}

--- a/internal/ui/showcase/accordion_card.templ
+++ b/internal/ui/showcase/accordion_card.templ
@@ -1,0 +1,47 @@
+package showcase
+
+import (
+	"github.com/templui/templui/components/accordion"
+	"github.com/templui/templui/components/card"
+)
+
+templ AccordionCard() {
+	@card.Card(card.Props{Class: "w-full max-w-sm"}) {
+		@card.Header() {
+			@card.Title() {
+				Subscription & Billing
+			}
+			@card.Description() {
+				Common questions about your account, plans, payments and cancellations.
+			}
+		}
+		@card.Content() {
+			@accordion.Accordion() {
+				@accordion.Item(accordion.ItemProps{Open: true}) {
+					@accordion.Trigger() {
+						What subscription plans do you offer?
+					}
+					@accordion.Content() {
+						We offer three subscription tiers: Starter, Professional, and Enterprise. Each plan includes increasing storage limits, API access, and team collaboration features.
+					}
+				}
+				@accordion.Item() {
+					@accordion.Trigger() {
+						How does billing work?
+					}
+					@accordion.Content() {
+						Billing occurs automatically at the start of each billing cycle. We accept all major credit cards and PayPal.
+					}
+				}
+				@accordion.Item() {
+					@accordion.Trigger() {
+						How do I cancel my subscription?
+					}
+					@accordion.Content() {
+						You can cancel your subscription anytime from your account settings. Your access will continue until the end of your current billing period.
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/ui/showcase/accordion_default.templ
+++ b/internal/ui/showcase/accordion_default.templ
@@ -4,10 +4,8 @@ import "github.com/templui/templui/components/accordion"
 
 templ AccordionDefault() {
 	<div class="w-full max-w-sm">
-		@accordion.Accordion(accordion.Props{
-			Class: "w-full",
-		}) {
-			@accordion.Item() {
+		@accordion.Accordion() {
+			@accordion.Item(accordion.ItemProps{Open: true}) {
 				@accordion.Trigger() {
 					Is it accessible?
 				}
@@ -25,10 +23,10 @@ templ AccordionDefault() {
 			}
 			@accordion.Item() {
 				@accordion.Trigger() {
-					Is it animated?
+					Is it CSS-only?
 				}
 				@accordion.Content() {
-					Yes. It is animated by default, but you can disable it if you prefer.
+					Yes. It uses native details and summary elements with no JavaScript.
 				}
 			}
 		}

--- a/internal/ui/showcase/accordion_disabled.templ
+++ b/internal/ui/showcase/accordion_disabled.templ
@@ -1,0 +1,34 @@
+package showcase
+
+import "github.com/templui/templui/components/accordion"
+
+templ AccordionDisabled() {
+	<div class="w-full max-w-lg">
+		@accordion.Accordion() {
+			@accordion.Item() {
+				@accordion.Trigger() {
+					Can I access my account history?
+				}
+				@accordion.Content() {
+					Yes, you can view your complete account history including all transactions, plan changes, and support tickets in the Account History section of your dashboard.
+				}
+			}
+			@accordion.Item(accordion.ItemProps{Disabled: true}) {
+				@accordion.Trigger() {
+					Premium feature information
+				}
+				@accordion.Content() {
+					This section contains information about premium features. Upgrade your plan to access this content.
+				}
+			}
+			@accordion.Item() {
+				@accordion.Trigger() {
+					How do I update my email address?
+				}
+				@accordion.Content() {
+					You can update your email address in your account settings. You'll receive a verification email at your new address to confirm the change.
+				}
+			}
+		}
+	</div>
+}

--- a/internal/ui/showcase/accordion_multiple.templ
+++ b/internal/ui/showcase/accordion_multiple.templ
@@ -1,0 +1,34 @@
+package showcase
+
+import "github.com/templui/templui/components/accordion"
+
+templ AccordionMultiple() {
+	<div class="w-full max-w-lg">
+		@accordion.Accordion(accordion.Props{Multiple: true}) {
+			@accordion.Item(accordion.ItemProps{Open: true}) {
+				@accordion.Trigger() {
+					Notification Settings
+				}
+				@accordion.Content() {
+					Manage how you receive notifications. You can enable email alerts for updates or push notifications for mobile devices.
+				}
+			}
+			@accordion.Item() {
+				@accordion.Trigger() {
+					Privacy & Security
+				}
+				@accordion.Content() {
+					Control your privacy settings and security preferences. Enable two-factor authentication, manage connected devices, and review active sessions.
+				}
+			}
+			@accordion.Item() {
+				@accordion.Trigger() {
+					Billing & Subscription
+				}
+				@accordion.Content() {
+					View your current plan, payment history, and upcoming invoices. Update your payment method or change your subscription tier.
+				}
+			}
+		}
+	</div>
+}


### PR DESCRIPTION
## Summary
- Add typed `Multiple` / `Disabled` on `Accordion` and `Open` / `Disabled` on `Item`, mapped to native `<details>` / `<summary>` (no JS).
- Fix exclusive accordion grouping: items share a per-instance `name` (from `ID` or a generated id) instead of a hardcoded `"accordion"`, so multiple accordions on one page no longer interfere; `Multiple` omits `name`.
- Align root layout classes with shadcn base-nova (`flex w-full flex-col`) and keep the CSS-only chevron.
- Expand docs with Multiple, Disabled, Borders, and Card examples; update the default showcase (first item open; remove incorrect “animated” claim).

## Motivation
Bring templui’s accordion closer to the shadcn/ui (Base UI) accordion surface for the common examples: default open item, multiple open panels, disabled items, bordered container, and card composition — while staying on the intentional CSS-only `<details>` approach.

This originally stemmed from our need for having multiple accordions on a single page where one or more can have multiple accordion items open at the same time. In order to achieve this we make a alteration to the accordion component installed into our repo, but this is an attempt to upstream a more complete solution.

## API
| Prop       | Where            | Behavior                                   |
| ---------- | ---------------- | ------------------------------------------ |
| `Multiple` | Accordion        | Allow more than one open item              |
| `Disabled` | Accordion / Item | Non-interactive (`inert` + styles)         |
| `Open`     | Item             | Initial open state (maps to native `open`) |

Borders and card layouts remain composition via `Class` and the existing `card` component.

## Example Screenshots

### Multiple

<img width="891" height="621" alt="Screenshot 2026-07-15 at 9 40 51 PM" src="https://github.com/user-attachments/assets/cd231146-73e1-4e4f-a2a5-c0407aed4ef0" />

### Disabled

<img width="904" height="444" alt="Screenshot 2026-07-15 at 9 40 55 PM" src="https://github.com/user-attachments/assets/a744d3a8-f355-4eeb-bd32-0a3901471503" />

### Borders

<img width="900" height="513" alt="Screenshot 2026-07-15 at 9 41 06 PM" src="https://github.com/user-attachments/assets/7fa1a65f-05fd-4d48-9c55-eecfa7c60641" />

### Card

<img width="901" height="608" alt="Screenshot 2026-07-15 at 9 41 11 PM" src="https://github.com/user-attachments/assets/b00ecdd7-9330-412f-afbe-0ca01bbf1953" />

### API Reference

<img width="917" height="741" alt="Screenshot 2026-07-15 at 9 41 30 PM" src="https://github.com/user-attachments/assets/fb206730-993e-4bb0-a575-61ea7b1b0b66" />

## Out of scope
- Controlled `value` / `onValueChange`
- Panel height animation / accordion JS
- RTL-specific demo

## Test plan
- [x] Default: first item open; exclusive open within one accordion
- [x] Two accordions on one page: opening an item in one does not close the other
- [x] `Multiple: true`: several items can stay open
- [x] Item / root `Disabled`: cannot toggle; styles look disabled
- [x] Borders and Card showcases render as in docs